### PR TITLE
chore: promote quickstart to version 0.0.1

### DIFF
--- a/config-root/namespaces/jx-staging/quickstart/quickstart-ingress.yaml
+++ b/config-root/namespaces/jx-staging/quickstart/quickstart-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: quickstart/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: quickstart
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: quickstart
+              servicePort: 80
+      host: quickstart-jx-staging.35.193.120.113.nip.io

--- a/config-root/namespaces/jx-staging/quickstart/quickstart-quickstart-deploy.yaml
+++ b/config-root/namespaces/jx-staging/quickstart/quickstart-quickstart-deploy.yaml
@@ -1,0 +1,59 @@
+# Source: quickstart/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: quickstart-quickstart
+  labels:
+    draft: draft-app
+    chart: "quickstart-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: quickstart-quickstart
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: quickstart-quickstart
+    spec:
+      serviceAccountName: quickstart-quickstart
+      containers:
+        - name: quickstart
+          image: "gcr.io/artful-zone-312202/quickstart:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/quickstart/quickstart-quickstart-sa.yaml
+++ b/config-root/namespaces/jx-staging/quickstart/quickstart-quickstart-sa.yaml
@@ -1,0 +1,8 @@
+# Source: quickstart/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: quickstart-quickstart
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/quickstart/quickstart-svc.yaml
+++ b/config-root/namespaces/jx-staging/quickstart/quickstart-svc.yaml
@@ -1,0 +1,18 @@
+# Source: quickstart/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: quickstart
+  labels:
+    chart: "quickstart-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: quickstart-quickstart

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,12 @@
 	      <td><a href='https://github.com/jenkins-x-plugins/jx-verify'>source</a></td>
 	    </tr>
     <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> quickstart </a></td>
+	      <td>0.0.1</td>
+	      <td><a href='http://quickstart-jx-staging.35.193.120.113.nip.io'>view</a></td>
+	      <td></td>
+	    </tr>
+    <tr>
 		      <td colspan='4'><h3>jx</h3></td>
 		    </tr>
 	    <tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -28,6 +28,21 @@
     repositoryName: jx3
     repositoryUrl: https://storage.googleapis.com/jenkinsxio/charts
     resourcePath: config-root/namespaces/jx-staging/jx-verify
+  - apiVersion: v1
+    applicationUrl: http://quickstart-jx-staging.35.193.120.113.nip.io
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2021-04-29T10:15:33Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    ingresses:
+    - name: quickstart
+      url: http://quickstart-jx-staging.35.193.120.113.nip.io
+    lastDeployed: "2021-04-29T10:15:33Z"
+    logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=artful-zone-312202&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Ftf-jx-bold-heron%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Fquickstart&dateRangeUnbound=both
+    name: quickstart
+    repositoryName: dev
+    repositoryUrl: http://chartmuseum-jx.35.193.120.113.nip.io/
+    resourcePath: config-root/namespaces/jx-staging/quickstart
+    version: 0.0.1
 - namespace: jx
   path: helmfiles/jx/helmfile.yaml
   releases:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -6,11 +6,17 @@ environments:
 repositories:
 - name: jx3
   url: https://storage.googleapis.com/jenkinsxio/charts
+- name: dev
+  url: http://chartmuseum-jx.35.193.120.113.nip.io/
 releases:
 - chart: jx3/jx-verify
   name: jx-verify
   namespace: jx-staging
   values:
   - jx-values.yaml
+- chart: dev/quickstart
+  version: 0.0.1
+  name: quickstart
+  namespace: jx-staging
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -18,5 +18,7 @@ releases:
   version: 0.0.1
   name: quickstart
   namespace: jx-staging
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote quickstart to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
