### PR TITLE
chore: promote quickstart to version 0.0.3

### DIFF
--- a/config-root/namespaces/jx-staging/quickstart/quickstart-quickstart-deploy.yaml
+++ b/config-root/namespaces/jx-staging/quickstart/quickstart-quickstart-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: quickstart-quickstart
   labels:
     draft: draft-app
-    chart: "quickstart-0.0.2"
+    chart: "quickstart-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: quickstart-quickstart
       containers:
         - name: quickstart
-          image: "gcr.io/artful-zone-312202/quickstart:0.0.2"
+          image: "gcr.io/artful-zone-312202/quickstart:0.0.3"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.2
+              value: 0.0.3
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/quickstart/quickstart-svc.yaml
+++ b/config-root/namespaces/jx-staging/quickstart/quickstart-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: quickstart
   labels:
-    chart: "quickstart-0.0.2"
+    chart: "quickstart-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
 spec:

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@
 	    </tr>
     <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> quickstart </a></td>
-	      <td>0.0.2</td>
+	      <td>0.0.3</td>
 	      <td><a href='http://quickstart-jx-staging.35.193.120.113.nip.io'>view</a></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -31,18 +31,18 @@
   - apiVersion: v1
     applicationUrl: http://quickstart-jx-staging.35.193.120.113.nip.io
     description: A Helm chart for Kubernetes
-    firstDeployed: "2021-04-29T16:08:55Z"
+    firstDeployed: "2021-04-29T16:27:05Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
     ingresses:
     - name: quickstart
       url: http://quickstart-jx-staging.35.193.120.113.nip.io
-    lastDeployed: "2021-04-29T16:08:55Z"
+    lastDeployed: "2021-04-29T16:27:05Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=artful-zone-312202&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Ftf-jx-bold-heron%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Fquickstart&dateRangeUnbound=both
     name: quickstart
     repositoryName: dev
     repositoryUrl: http://chartmuseum-jx.35.193.120.113.nip.io/
     resourcePath: config-root/namespaces/jx-staging/quickstart
-    version: 0.0.2
+    version: 0.0.3
 - namespace: jx
   path: helmfiles/jx/helmfile.yaml
   releases:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -15,7 +15,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/quickstart
-  version: 0.0.2
+  version: 0.0.3
   name: quickstart
   namespace: jx-staging
   values:


### PR DESCRIPTION
chore: promote quickstart to version 0.0.3

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
