### PR TITLE
chore: promote node-http-watch-pipeline-activity to version 0.0.2

### DIFF
--- a/config-root/namespaces/jx-production/node-http-watch-pipeline-activity/node-http-watch-pipeline-activity-ingress.yaml
+++ b/config-root/namespaces/jx-production/node-http-watch-pipeline-activity/node-http-watch-pipeline-activity-ingress.yaml
@@ -1,0 +1,18 @@
+# Source: node-http-watch-pipeline-activity/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: node-http-watch-pipeline-activity
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: node-http-watch-pipeline-activity
+              servicePort: 80
+      host: node-http-watch-pipeline-activity-jx-production.35.193.120.113.nip.io

--- a/config-root/namespaces/jx-production/node-http-watch-pipeline-activity/node-http-watch-pipeline-activity-node-http-watch-pipeline-acti-deploy.yaml
+++ b/config-root/namespaces/jx-production/node-http-watch-pipeline-activity/node-http-watch-pipeline-activity-node-http-watch-pipeline-acti-deploy.yaml
@@ -1,0 +1,59 @@
+# Source: node-http-watch-pipeline-activity/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: node-http-watch-pipeline-activity-node-http-watch-pipeline-acti
+  labels:
+    draft: draft-app
+    chart: "node-http-watch-pipeline-activity-0.0.2"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-production
+  annotations:
+    wave.pusher.com/update-on-config-change: 'true'
+spec:
+  selector:
+    matchLabels:
+      app: node-http-watch-pipeline-activity-node-http-watch-pipeline-acti
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: node-http-watch-pipeline-activity-node-http-watch-pipeline-acti
+    spec:
+      serviceAccountName: node-http-watch-pipeline-activity-node-http-watch-pipeline-acti
+      containers:
+        - name: node-http-watch-pipeline-activity
+          image: "gcr.io/artful-zone-312202/node-http-watch-pipeline-activity:0.0.2"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.2
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-production/node-http-watch-pipeline-activity/node-http-watch-pipeline-activity-node-http-watch-pipeline-acti-sa.yaml
+++ b/config-root/namespaces/jx-production/node-http-watch-pipeline-activity/node-http-watch-pipeline-activity-node-http-watch-pipeline-acti-sa.yaml
@@ -1,0 +1,8 @@
+# Source: node-http-watch-pipeline-activity/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-http-watch-pipeline-activity-node-http-watch-pipeline-acti
+  namespace: jx-production
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-production/node-http-watch-pipeline-activity/node-http-watch-pipeline-activity-svc.yaml
+++ b/config-root/namespaces/jx-production/node-http-watch-pipeline-activity/node-http-watch-pipeline-activity-svc.yaml
@@ -1,0 +1,18 @@
+# Source: node-http-watch-pipeline-activity/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: node-http-watch-pipeline-activity
+  labels:
+    chart: "node-http-watch-pipeline-activity-0.0.2"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  namespace: jx-production
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: node-http-watch-pipeline-activity-node-http-watch-pipeline-acti

--- a/config-root/namespaces/jx-staging/node-http-watch-pipeline-activity/node-http-watch-pipeline-activity-node-http-watch-pipeline-acti-deploy.yaml
+++ b/config-root/namespaces/jx-staging/node-http-watch-pipeline-activity/node-http-watch-pipeline-activity-node-http-watch-pipeline-acti-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: node-http-watch-pipeline-activity-node-http-watch-pipeline-acti
   labels:
     draft: draft-app
-    chart: "node-http-watch-pipeline-activity-0.0.1"
+    chart: "node-http-watch-pipeline-activity-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: node-http-watch-pipeline-activity-node-http-watch-pipeline-acti
       containers:
         - name: node-http-watch-pipeline-activity
-          image: "gcr.io/artful-zone-312202/node-http-watch-pipeline-activity:0.0.1"
+          image: "gcr.io/artful-zone-312202/node-http-watch-pipeline-activity:0.0.2"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.1
+              value: 0.0.2
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/node-http-watch-pipeline-activity/node-http-watch-pipeline-activity-svc.yaml
+++ b/config-root/namespaces/jx-staging/node-http-watch-pipeline-activity/node-http-watch-pipeline-activity-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: node-http-watch-pipeline-activity
   labels:
-    chart: "node-http-watch-pipeline-activity-0.0.1"
+    chart: "node-http-watch-pipeline-activity-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
 spec:

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,7 @@
 	    </tr>
     <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> node-http-watch-pipeline-activity </a></td>
-	      <td>0.0.1</td>
+	      <td>0.0.2</td>
 	      <td><a href='http://node-http-watch-pipeline-activity-jx-staging.35.193.120.113.nip.io'>view</a></td>
 	      <td></td>
 	    </tr>

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,12 @@
 	      <td><a href='https://github.com/jenkins-x-plugins/jx-verify'>source</a></td>
 	    </tr>
     <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> node-http-watch-pipeline-activity </a></td>
+	      <td>0.0.2</td>
+	      <td><a href='http://node-http-watch-pipeline-activity-jx-production.35.193.120.113.nip.io'>view</a></td>
+	      <td></td>
+	    </tr>
+    <tr>
 		      <td colspan='4'><h3>jx-staging</h3></td>
 		    </tr>
 	    <tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -46,18 +46,18 @@
   - apiVersion: v1
     applicationUrl: http://node-http-watch-pipeline-activity-jx-staging.35.193.120.113.nip.io
     description: A Helm chart for Kubernetes
-    firstDeployed: "2021-05-02T15:45:27Z"
+    firstDeployed: "2021-05-02T15:52:25Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
     ingresses:
     - name: node-http-watch-pipeline-activity
       url: http://node-http-watch-pipeline-activity-jx-staging.35.193.120.113.nip.io
-    lastDeployed: "2021-05-02T15:45:27Z"
+    lastDeployed: "2021-05-02T15:52:25Z"
     logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=artful-zone-312202&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Ftf-jx-bold-heron%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Fnode-http-watch-pipeline-activity&dateRangeUnbound=both
     name: node-http-watch-pipeline-activity
     repositoryName: dev
     repositoryUrl: http://chartmuseum-jx.35.193.120.113.nip.io/
     resourcePath: config-root/namespaces/jx-staging/node-http-watch-pipeline-activity
-    version: 0.0.1
+    version: 0.0.2
 - namespace: jx
   path: helmfiles/jx/helmfile.yaml
   releases:

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -14,6 +14,21 @@
     repositoryName: jx3
     repositoryUrl: https://storage.googleapis.com/jenkinsxio/charts
     resourcePath: config-root/namespaces/jx-production/jx-verify
+  - apiVersion: v1
+    applicationUrl: http://node-http-watch-pipeline-activity-jx-production.35.193.120.113.nip.io
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2021-05-02T15:52:39Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    ingresses:
+    - name: node-http-watch-pipeline-activity
+      url: http://node-http-watch-pipeline-activity-jx-production.35.193.120.113.nip.io
+    lastDeployed: "2021-05-02T15:52:39Z"
+    logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=artful-zone-312202&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Ftf-jx-bold-heron%2Fnamespace_name%2Fjx-production%2Fcontainer_name%2Fnode-http-watch-pipeline-activity&dateRangeUnbound=both
+    name: node-http-watch-pipeline-activity
+    repositoryName: dev
+    repositoryUrl: http://chartmuseum-jx.35.193.120.113.nip.io/
+    resourcePath: config-root/namespaces/jx-production/node-http-watch-pipeline-activity
+    version: 0.0.2
 - namespace: jx-staging
   path: helmfiles/jx-staging/helmfile.yaml
   releases:

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -18,5 +18,7 @@ releases:
   version: 0.0.2
   name: node-http-watch-pipeline-activity
   namespace: jx-production
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -6,11 +6,17 @@ environments:
 repositories:
 - name: jx3
   url: https://storage.googleapis.com/jenkinsxio/charts
+- name: dev
+  url: http://chartmuseum-jx.35.193.120.113.nip.io/
 releases:
 - chart: jx3/jx-verify
   name: jx-verify
   namespace: jx-production
   values:
   - jx-values.yaml
+- chart: dev/node-http-watch-pipeline-activity
+  version: 0.0.2
+  name: node-http-watch-pipeline-activity
+  namespace: jx-production
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -21,7 +21,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/node-http-watch-pipeline-activity
-  version: 0.0.1
+  version: 0.0.2
   name: node-http-watch-pipeline-activity
   namespace: jx-staging
   values:


### PR DESCRIPTION
chore: promote node-http-watch-pipeline-activity to version 0.0.2

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
